### PR TITLE
log: add support for displaying topics

### DIFF
--- a/src/hg_actions.rs
+++ b/src/hg_actions.rs
@@ -112,7 +112,7 @@ impl<'a> VersionControlActions for HgActions {
             .collect();
         self.revision_shortcut.update_hashes(hashes);
 
-        let template = "{label(ifeq(phase, 'secret', 'yellow', ifeq(phase, 'draft', 'yellow', 'red')), node|short)}{ifeq(branch, 'default', '', label('green', ' ({branch})'))}{bookmarks % ' {bookmark}{ifeq(bookmark, active, '*')}{bookmark}'}{label('yellow', tags % ' {tag}')} {label('magenta', author|person)} {desc|firstline|strip}";
+        let template = "{label('green', if(topics, '[{topics}]'))} {label(ifeq(phase, 'secret', 'yellow', ifeq(phase, 'draft', 'yellow', 'red')), node|short)}{ifeq(branch, 'default', '', label('green', ' ({branch})'))}{bookmarks % ' {bookmark}{ifeq(bookmark, active, '*')}{bookmark}'}{label('yellow', tags % ' {tag}')} {label('magenta', author|person)} {desc|firstline|strip}";
         let mut output = handle_command(
             self.command()
                 .arg("log")


### PR DESCRIPTION
Right now topics will always be green, but we should later have different (but stable) colors IMO