### PR TITLE
commands: add support for `hg export`/`git show` for the current revision

### DIFF
--- a/src/git_actions.rs
+++ b/src/git_actions.rs
@@ -92,6 +92,13 @@ impl VersionControlActions for GitActions {
                 .args(&["-c", "color.status=always", "status"]),
         )
     }
+    
+    fn current_export(&mut self) -> Result<String, String> {
+        handle_command(
+            self.command()
+                .args(&["show", "--color"]),
+        )
+    }
 
     fn log(&mut self, count: u32) -> Result<String, String> {
         let count_str = format!("-{}", count);

--- a/src/hg_actions.rs
+++ b/src/hg_actions.rs
@@ -100,6 +100,10 @@ impl<'a> VersionControlActions for HgActions {
         Ok(output)
     }
 
+    fn current_export(&mut self) -> Result<String, String> {
+        handle_command(self.command().args(&["export", "--color", "always"]))
+    }
+
     fn log(&mut self, count: u32) -> Result<String, String> {
         let count_str = format!("{}", count);
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -190,6 +190,11 @@ where
                 }
             }),
             ['d'] => Ok(HandleChordResult::Unhandled),
+            ['e'] => Ok(HandleChordResult::Unhandled),
+            ['e', 'e'] => self.command_context("current full revision", |s, h| {
+                let result = s.version_control.current_export();
+                s.handle_result(h, result)
+            }),
             ['d', 'd'] => self.command_context("current diff all", |s, h| {
                 let result = s.version_control.current_diff_all();
                 s.handle_result(h, result)
@@ -558,6 +563,7 @@ where
 
         write.queue(cursor::MoveToNextLine(1))?;
 
+        Self::show_help_action(&mut write, "ee", "revision full contents")?;
         Self::show_help_action(&mut write, "dd", "current diff all")?;
         Self::show_help_action(&mut write, "ds", "current diff selected")?;
         Self::show_help_action(&mut write, "DC", "revision changes")?;

--- a/src/version_control_actions.rs
+++ b/src/version_control_actions.rs
@@ -11,6 +11,8 @@ pub trait VersionControlActions {
     fn version(&mut self) -> Result<String, String>;
 
     fn status(&mut self) -> Result<String, String>;
+    /// Shows the header and all diffs for the current revision
+    fn current_export(&mut self) -> Result<String, String>;
     fn log(&mut self, count: u32) -> Result<String, String>;
 
     fn current_diff_all(&mut self) -> Result<String, String>;


### PR DESCRIPTION
This is a very common command in VCS, it should be present.